### PR TITLE
don't ignore go mod command errors

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -146,12 +146,11 @@ def cmd_go_mod(cmd, dir):
         output = check_output(["go", "mod", cmd], cwd=dir).decode("utf-8").strip()
         if output:
             log.info(output)
-        return True
     except CalledProcessError as e:
         error = e.output.decode("utf-8").strip()
         if error:
             log.info(error)
-        return False
+        raise
 
 
 def main():


### PR DESCRIPTION
Currently, errors returned by the `go mod` commands are ignored,
even though the error output is printed. This can lead to situations
where the service completes successfully, but doesn't actually do
anything, as is sometimes the case where the `vendor` folder is already
included in the code base.