### PR TITLE
Fix unsupported characters in XML

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -90,9 +90,9 @@ def archive_autodetect():
         exit(1)
     else:
         spec_dir = spec.parent  # typically the same as cwd
-        spec_stem = spec.stem  # stem is app in app.spec
+        spec_stem = spec.stem.split(":")[-1] # stem is app in app.spec
         # highest sorted archive under spec_dir
-        pattern = f"{spec.stem}*.{archive_ext}"
+        pattern = f"*{spec_stem}*.{archive_ext}"
         archive = next(reversed(sorted(Path(spec_dir).glob(pattern))), None)
     if not archive:
         log.error(f"Archive autodetection found no matching archive under {cwd}")

--- a/go_modules.service
+++ b/go_modules.service
@@ -3,7 +3,7 @@
   <description>This service extracts a Go application source,
   reads the files go.mod and go.sum,
   downloads and verifies Go module dependencies,
-  and creates a vendor.tar[.<tar compression>] to be committed allowing fully offline
+  and creates a vendor.tar[.&lt;tar compression&gt;] to be committed allowing fully offline
   builds of Go applications.</description>
   <parameter name="strategy">
     <description>Choose the strategy this service runs in. Values: vendor. Default: vendor</description>


### PR DESCRIPTION
go_modules service cannot be used on OBS server and generates an obscure error:
```
  400 remote error:
  Error (http://obs2:5152/sourceupdate/project/golang-test)
```

This is due to an invalid syntax in XML description field:  '<' and '>'
characters are not valid in value string.