### PR TITLE
Add --subdir argument to allow for go.mod files in different locations & numerous fixes

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -82,12 +82,27 @@ def get_archive_parameters(args):
 
 
 def basename_from_archive_name(archive_name):
-    return re.sub(
+    basename = re.sub(
         "^(?P<service_prefix>_service:[^:]+:)?(?P<basename>.*)\.(?P<extension>obscpio|tar\.[^\.]+)$",
         r"\g<basename>",
         archive_name,
     )
+    if basename:
+        log.info(f"Detected basename {basename} form archive name")
+    return basename
 
+def basename_from_archive(archive_name):
+    paths = []
+    with libarchive.file_reader(archive_name) as archive:
+        for entry in archive:
+            if (entry.isdir):
+                paths.append(entry.name)
+        try:
+            basename = os.path.commonpath(paths)
+        except  ValueError:
+            return
+    log.info(f"Detected basename {basename} from archive")
+    return basename
 
 def archive_autodetect():
     """Find the most likely candidate file that contains go.mod and go.sum.
@@ -205,10 +220,10 @@ def main():
     archive = args.archive or archive_autodetect()
     log.info(f"Using archive {archive}")
 
-    basename = basename_from_archive_name(archive)
+    basename = basename_from_archive(archive) or basename_from_archive_name(archive)
     extract(archive, outdir)
 
-    go_mod_path = find_file(outdir, "go.mod")
+    go_mod_path = find_file(os.path.join(outdir,basename), "go.mod")
     if go_mod_path:
         go_mod_dir = os.path.dirname(go_mod_path)
         log.info(f"Using go.mod found at {go_mod_path}")

--- a/go_modules
+++ b/go_modules
@@ -33,6 +33,7 @@ import re
 import libarchive
 import os
 import shutil
+import tempfile
 
 from pathlib import Path
 from subprocess import run
@@ -221,69 +222,62 @@ def main():
     archive = args.archive or archive_autodetect()
     log.info(f"Using archive {archive}")
 
-    extract(archive, outdir)
-    basename = args.basename or basename_from_archive(archive) or basename_from_archive_name(archive)
+    with tempfile.TemporaryDirectory() as tempdir:
+        extract(archive, tempdir)
+        basename = args.basename or basename_from_archive(archive) or basename_from_archive_name(archive)
 
-    go_mod_path = find_file(os.path.join(outdir,basename), "go.mod")
-    if go_mod_path:
-        go_mod_dir = os.path.dirname(go_mod_path)
-        log.info(f"Using go.mod found at {go_mod_path}")
-    else:
-        log.error(f"File go.mod not found under {outdir}")
-        exit(1)
+        go_mod_path = find_file(os.path.join(tempdir, basename), "go.mod")
+        if go_mod_path:
+            go_mod_dir = os.path.dirname(go_mod_path)
+            log.info(f"Using go.mod found at {go_mod_path}")
+        else:
+            log.error(f"File go.mod not found under {os.path.join(tempdir, basename)}")
+            exit(1)
 
-    if args.strategy == "vendor":
-        # go subcommand sequence:
-        # - go mod download
-        #   (is sensitive to invalid module versions, try and log warn if fails)
-        # - go mod vendor
-        #   (also downloads but use separate steps for visibility in OBS environment)
-        # - go mod verify
-        #   (validates checksums)
+        if args.strategy == "vendor":
+            # go subcommand sequence:
+            # - go mod download
+            #   (is sensitive to invalid module versions, try and log warn if fails)
+            # - go mod vendor
+            #   (also downloads but use separate steps for visibility in OBS environment)
+            # - go mod verify
+            #   (validates checksums)
 
-        # return value cp is type subprocess.CompletedProcess
-        cp = cmd_go_mod("download", go_mod_dir)
-        if cp.returncode:
-            if "invalid version" in cp.stderr:
-                log.warning(
-                    f"go mod download is more sensitive to invalid module versions than go mod vendor"
-                )
-                log.warning(
-                    f"if go mod vendor and go mod verify complete, vendoring is successful"
-                )
-            else:
-                log.error("go mod download failed")
+            # return value cp is type subprocess.CompletedProcess
+            cp = cmd_go_mod("download", go_mod_dir)
+            if cp.returncode:
+                if "invalid version" in cp.stderr:
+                    log.warning(
+                        f"go mod download is more sensitive to invalid module versions than go mod vendor"
+                    )
+                    log.warning(
+                        f"if go mod vendor and go mod verify complete, vendoring is successful"
+                    )
+                else:
+                    log.error("go mod download failed")
+                    exit(1)
+
+            cp = cmd_go_mod("vendor", go_mod_dir)
+            if cp.returncode:
+                log.error("go mod vendor failed")
                 exit(1)
 
-        cp = cmd_go_mod("vendor", go_mod_dir)
-        if cp.returncode:
-            log.error("go mod vendor failed")
-            exit(1)
+            cp = cmd_go_mod("verify", go_mod_dir)
+            if cp.returncode:
+                log.error("go mod verify failed")
+                exit(1)
 
-        cp = cmd_go_mod("verify", go_mod_dir)
-        if cp.returncode:
-            log.error("go mod verify failed")
-            exit(1)
+            log.info(f"Vendor go.mod dependencies to {vendor_tarname}")
+            vendor_tarfile = os.path.join(outdir, vendor_tarname)
+            cwd = os.getcwd()
+            os.chdir(go_mod_dir)
+            vendor_dir = "vendor"
 
-        log.info(f"Vendor go.mod dependencies to {vendor_tarname}")
-        vendor_tarfile = os.path.join(outdir, vendor_tarname)
-        cwd = os.getcwd()
-        os.chdir(go_mod_dir)
-        vendor_dir = "vendor"
-
-        with libarchive.file_writer(
-            vendor_tarfile, archive_format, archive_compression
-        ) as new_archive:
-            new_archive.add_files(vendor_dir)
-        os.chdir(cwd)
-
-        # remove extracted Go application source
-        try:
-            to_remove = os.path.join(outdir, basename)
-            log.info(f"Cleaning up working dir {to_remove}")
-            shutil.rmtree(to_remove)
-        except FileNotFoundError:
-            log.error(f"Could not remove directory not found {to_remove}")
+            with libarchive.file_writer(
+                    vendor_tarfile, archive_format, archive_compression
+            ) as new_archive:
+                new_archive.add_files(vendor_dir)
+            os.chdir(cwd)
 
 
 if __name__ == "__main__":

--- a/go_modules
+++ b/go_modules
@@ -33,6 +33,7 @@ import re
 import libarchive
 import os
 import shutil
+import sys
 import tempfile
 
 from pathlib import Path
@@ -190,7 +191,10 @@ def cmd_go_mod(cmd, dir):
     """
     log.info(f"go mod {cmd}")
     # subprocess.run() returns CompletedProcess cp
-    cp = run(["go", "mod", cmd], cwd=dir, capture_output=True, text=True)
+    if sys.version_info >= (3, 7):
+        cp = run(["go", "mod", cmd], cwd=dir, capture_output=True, text=True)
+    else:
+        cp = run(["go", "mod", cmd], cwd=dir)
     if cp.returncode:
         log.error(cp.stderr.strip())
     return cp

--- a/go_modules
+++ b/go_modules
@@ -182,12 +182,6 @@ def extract(filename, outdir):
     os.chdir(cwd)
 
 
-def find_file(path, filename):
-    for root, dirs, files in os.walk(path):
-        if filename in files:
-            return os.path.join(root, filename)
-
-
 def cmd_go_mod(cmd, dir):
     """Execute go mod subcommand using subprocess.run().
     Capture both stderr and stdout as text.
@@ -201,6 +195,12 @@ def cmd_go_mod(cmd, dir):
         log.error(cp.stderr.strip())
     return cp
 
+def sanitize_subdir(dir, subdir):
+    ret = os.path.normpath(subdir)
+    if dir == os.path.commonpath([dir, ret]):
+        return ret
+    log.error("Invalid path: {ret} not subdir of {dir}")
+    exit (1)
 
 def main():
     log.info(f"Running OBS Source Service: {app_name}")
@@ -213,9 +213,11 @@ def main():
     parser.add_argument("--outdir")
     parser.add_argument("--compression", default=DEFAULT_COMPRESSION)
     parser.add_argument("--basename")
+    parser.add_argument("--subdir")
     args = parser.parse_args()
 
     outdir = args.outdir
+    subdir = args.subdir
 
     archive_format, archive_compression, archive_ext = get_archive_parameters(args)
     vendor_tarname = f"vendor.{archive_ext}"
@@ -224,10 +226,10 @@ def main():
 
     with tempfile.TemporaryDirectory() as tempdir:
         extract(archive, tempdir)
-        basename = args.basename or basename_from_archive(archive) or basename_from_archive_name(archive)
 
-        go_mod_path = find_file(os.path.join(tempdir, basename), "go.mod")
-        if go_mod_path:
+        basename = args.basename or basename_from_archive(archive) or basename_from_archive_name(archive)
+        go_mod_path = sanitize_subdir(tempdir, os.path.join(tempdir, basename, subdir, "go.mod"))
+        if go_mod_path and os.path.exists(go_mod_path):
             go_mod_dir = os.path.dirname(go_mod_path)
             log.info(f"Using go.mod found at {go_mod_path}")
         else:

--- a/go_modules
+++ b/go_modules
@@ -211,6 +211,7 @@ def main():
     parser.add_argument("--archive")
     parser.add_argument("--outdir")
     parser.add_argument("--compression", default=DEFAULT_COMPRESSION)
+    parser.add_argument("--basename")
     args = parser.parse_args()
 
     outdir = args.outdir
@@ -220,8 +221,8 @@ def main():
     archive = args.archive or archive_autodetect()
     log.info(f"Using archive {archive}")
 
-    basename = basename_from_archive(archive) or basename_from_archive_name(archive)
     extract(archive, outdir)
+    basename = args.basename or basename_from_archive(archive) or basename_from_archive_name(archive)
 
     go_mod_path = find_file(os.path.join(outdir,basename), "go.mod")
     if go_mod_path:

--- a/go_modules
+++ b/go_modules
@@ -179,6 +179,7 @@ def extract(filename, outdir):
         libarchive.extract_file(filename)
     except libarchive.exception.ArchiveError as archive_error:
         log.error(archive_error)
+        exit(1)
 
     os.chdir(cwd)
 

--- a/go_modules
+++ b/go_modules
@@ -233,7 +233,10 @@ def main():
         extract(archive, tempdir)
 
         basename = args.basename or basename_from_archive(archive) or basename_from_archive_name(archive)
-        go_mod_path = sanitize_subdir(tempdir, os.path.join(tempdir, basename, subdir, "go.mod"))
+        if subdir:
+            go_mod_path = sanitize_subdir(tempdir, os.path.join(tempdir, basename, subdir, "go.mod"))
+        else:
+            go_mod_path = sanitize_subdir(tempdir, os.path.join(tempdir, basename, "go.mod"))
         if go_mod_path and os.path.exists(go_mod_path):
             go_mod_dir = os.path.dirname(go_mod_path)
             log.info(f"Using go.mod found at {go_mod_path}")

--- a/go_modules.service
+++ b/go_modules.service
@@ -16,5 +16,7 @@
   </parameter>
   <parameter name="basename">
     <description>Normally the go_modules service is able to determine the name of the top directory. Should this not be possible for some reason, use this option to specify.</description>
+  <parameter name="subdir">
+    <description>If go.mod is not available in the top directory of the archive, specify its path (relative to the top directory).</description>
   </parameter>
 </service>

--- a/go_modules.service
+++ b/go_modules.service
@@ -14,4 +14,7 @@
   <parameter name="compression">
     <description>Specify the source / vendor tarballs compression method. When using "tar" no compression is applied. Default: "gz".</description>
   </parameter>
+  <parameter name="basename">
+    <description>Normally the go_modules service is able to determine the name of the top directory. Should this not be possible for some reason, use this option to specify.</description>
+  </parameter>
 </service>


### PR DESCRIPTION
Some Go projects may have sub-projects that are build independently. These come in subdirectories with their own go.mod. Allow to specify the directory where to search for a go.mod file.

While testing this there were numerous other issues which had to be addressed as well:
- the output vendor.tar.* file was not compressed correctly
- name of the top directory in the input tarball may not match tar-ball name.
- An empty --compression flag should just fall back to  DEFAULT_COMPRESSION.