### PR TITLE
Fix compression parameter default value usage

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -53,7 +53,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument("--strategy", default="vendor")
 parser.add_argument("--archive")
 parser.add_argument("--outdir")
-parser.add_argument("--compression")
+parser.add_argument("--compression", default=DEFAULT_COMPRESSION)
 args = parser.parse_args()
 
 outdir = args.outdir
@@ -67,7 +67,7 @@ def get_archive_extension():
     if args.compression == "tar":
         return  "tar"
 
-    return "tar." + (args.compression or DEFAULT_COMPRESSION)
+    return "tar." + (args.compression)
 
 
 archive_ext = get_archive_extension()


### PR DESCRIPTION
Fix for default compression usage.
Otherwise, we start getting the next error:
```
ERROR:obs-service-go_modules:The specified compression mode is not supported: "None"
```