### PR TITLE
 make vendor tarball name configurable

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -43,6 +43,7 @@ app_name = "obs-service-go_modules"
 description = __doc__
 
 DEFAULT_COMPRESSION = "gz"
+DEFAULT_VENDOR_FILENAME = "vendor.tar"
 
 
 def get_archive_parameters(args):
@@ -79,8 +80,9 @@ def get_archive_parameters(args):
         archive_format = "gnutar"
         archive_compression = compression_format
         archive_extension = "tar." + (args.compression)
+        vendor_filename = args.vendorfilename
 
-    return archive_format, archive_compression, archive_extension
+    return archive_format, archive_compression, archive_extension, vendor_filename
 
 
 def basename_from_archive_name(archive_name):
@@ -227,14 +229,17 @@ def main():
     parser.add_argument("--outdir")
     parser.add_argument("--compression", default=DEFAULT_COMPRESSION)
     parser.add_argument("--basename")
+    parser.add_argument("--vendorfilename", default=DEFAULT_VENDOR_FILENAME)
     parser.add_argument("--subdir")
     args = parser.parse_args()
 
     outdir = args.outdir
     subdir = args.subdir
 
-    archive_format, archive_compression, archive_ext = get_archive_parameters(args)
-    vendor_tarname = f"vendor.{archive_ext}"
+    archive_format, archive_compression, archive_ext, vendor_filename = get_archive_parameters(
+        args
+    )
+    vendor_tarname = f"{vendor_filename}.{archive_ext}"
     archive = args.archive or archive_autodetect()
     log.info(f"Using archive {archive}")
 

--- a/go_modules.service
+++ b/go_modules.service
@@ -16,4 +16,7 @@
   <parameter name="subdir">
     <description>If go.mod is not available in the top directory of the archive, specify its path (relative to the top directory). Default: None.</description>
   </parameter>
+  <parameter name="vendorfilename">
+    <description>Specify the filename for the generated vendor tarball. Default: vendor</description>
+  </parameter>
 </service>


### PR DESCRIPTION
Tested locally, worked. Please point out any things you find, not sure if I followed all python best practices... :-)

`_service` file:
```
<services>
[...]
  <service name="go_modules" mode="disabled">
    <param name="vendorfilename">something-else-than-vendor</param>
  </service>
</services>
```

```bash
[...]
INFO:obs-service-go_modules:Vendor go.mod dependencies to something-else-than-vendor.tar.gz
```