### PR TITLE
Fix #29 config flake8 to ignore E501 long lines and revert flake8 shortened lines

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 88
-extend-ignore = E203
+extend-ignore = E203,E501

--- a/go_modules
+++ b/go_modules
@@ -70,10 +70,7 @@ def get_archive_parameters(args):
             compression_format = "zstd"
 
         if compression_format not in libarchive.ffi.READ_FILTERS:
-            log.error(
-                "The specified compression mode is not supported:"
-                + f'"{args.compression}"'
-            )
+            log.error(f"The specified compression mode is not supported: {args.compression}")
             exit(1)
 
         archive_format = "gnutar"
@@ -85,7 +82,7 @@ def get_archive_parameters(args):
 
 def basename_from_archive_name(archive_name):
     basename = re.sub(
-        r"^(?P<service_prefix>_service:[^:]+:)?(?P<basename>.*)\.(?P<extension>obscpio|tar\.[^\.]+)$",  # noqa: E501
+        r"^(?P<service_prefix>_service:[^:]+:)?(?P<basename>.*)\.(?P<extension>obscpio|tar\.[^\.]+)$",
         r"\g<basename>",
         archive_name,
     )
@@ -110,8 +107,7 @@ def basename_from_archive(archive_name):
 
 def archive_autodetect():
     """Find the most likely candidate file that contains go.mod and go.sum.
-    For most Go applications this will be app-x.y.z.tar.gz or other supported
-    compression.
+    For most Go applications this will be app-x.y.z.tar.gz or other supported compression.
     Use the name of the .spec file as the stem for the archive to detect.
     Archive formats supported:
     - .tar.bz2
@@ -163,10 +159,7 @@ def archive_autodetect():
             log.warning(f"Version not found in {spec.name}")
         else:
             if not (version in archive.name):
-                log.warning(
-                    f"Version {version} in {spec.name} "
-                    + f"does not match {archive.name}"
-                )
+                log.warning(f"Version {version} in {spec.name} does not match {archive.name}")
     return str(archive.name)  # return string not PosixPath
 
 
@@ -175,8 +168,7 @@ def extract(filename, outdir):
 
     cwd = os.getcwd()
 
-    # make path absolute so we can switch away from the
-    # current working directory
+    # make path absolute so we can switch away from the current working directory
     filename = os.path.join(cwd, filename)
 
     log.info(f"Switching to {outdir}")
@@ -258,19 +250,15 @@ def main():
             go_mod_dir = os.path.dirname(go_mod_path)
             log.info(f"Using go.mod found at {go_mod_path}")
         else:
-            log.error(
-                "File go.mod not found under " + f"{os.path.join(tempdir, basename)}"
-            )
+            log.error(f"File go.mod not found under {os.path.join(tempdir, basename)}")
             exit(1)
 
         if args.strategy == "vendor":
             # go subcommand sequence:
             # - go mod download
-            #   (is sensitive to invalid module versions,
-            #   try and log warn if fails)
+            #   (is sensitive to invalid module versions, try and log warn if fails)
             # - go mod vendor
-            #   (also downloads but use separate steps for visibility in
-            #   OBS environment)
+            #   (also downloads but use separate steps for visibility in OBS environment)
             # - go mod verify
             #   (validates checksums)
 
@@ -279,12 +267,10 @@ def main():
             if cp.returncode:
                 if "invalid version" in cp.stderr:
                     log.warning(
-                        "go mod download is more sensitive to invalid "
-                        + "module versions than go mod vendor"
+                        "go mod download is more sensitive to invalid module versions than go mod vendor"
                     )
                     log.warning(
-                        "if go mod vendor and go mod verify complete, "
-                        + "vendoring is successful"
+                        "if go mod vendor and go mod verify complete, vendoring is successful"
                     )
                 else:
                     log.error("go mod download failed")


### PR DESCRIPTION
Add configuration to ignore flake8 warning E501 about long lines. Revert previous E501 changes recommended by flake8.  This will reduce overall diff for security reviewers and assist automatic rebase of open PRs currently in review.
