### PR TITLE
Support archives with no base folder

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -87,7 +87,7 @@ def basename_from_archive_name(archive_name):
         archive_name,
     )
     if basename:
-        log.info(f"Detected basename {basename} form archive name")
+        log.info(f"Detected basename {basename} from archive name")
     return basename
 
 
@@ -203,7 +203,7 @@ def sanitize_subdir(basedir, subdir):
     ret = os.path.normpath(subdir)
     if basedir == os.path.commonpath([basedir, ret]):
         return ret
-    log.error("Invalid path: {ret} not subdir of {basedir}")
+    log.error(f"Invalid path: {ret} not subdir of {basedir}")
     exit(1)
 
 
@@ -240,11 +240,13 @@ def main():
     with tempfile.TemporaryDirectory() as tempdir:
         extract(archive, tempdir)
 
-        basename = (
-            args.basename
-            or basename_from_archive(archive)
-            or basename_from_archive_name(archive)
-        )
+        if args.basename is not None:
+            basename = args.basename
+        else:
+            basename = (
+                basename_from_archive(archive)
+                or basename_from_archive_name(archive)
+            )
         if subdir:
             go_mod_path = sanitize_subdir(
                 tempdir, os.path.join(tempdir, basename, subdir, "go.mod")


### PR DESCRIPTION
This PR solves the case where the `basename` option is specified with an empty value, but it is ignored and defaulting to an autodetected path.

This case happens when the application archive does not contain a basename at all. I.e., there isn't any folder in its root containing the rest of files:

```
$ mkdir testfolder
$ tar xz test.tgz -C testfolder
$ ls testfolder
file1
file2
```

This PR also takes the opportunity to fix a couple of typos in the related log lines:

```
INFO:obs-service-go_modules:Detected basename /path/to/archive.tgz form archive name
ERROR:obs-service-go_modules:Invalid path: {ret} not subdir of {basedir}
```