### PR TITLE
Make output archives more reproducible

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -174,7 +174,7 @@ def extract(filename, outdir):
     os.chdir(outdir)
 
     try:
-        libarchive.extract_file(filename)
+        libarchive.extract_file(filename, libarchive.extract.EXTRACT_TIME)
     except libarchive.exception.ArchiveError as archive_error:
         log.error(archive_error)
         exit(1)
@@ -299,16 +299,21 @@ def main():
             os.chdir(go_mod_dir)
             vendor_dir = "vendor"
 
-            kwargs = {}
+            mtime = os.path.getmtime(go_mod_path)
+            log.debug(f"Set archive files times to {mtime}")
+
+            options = []
+            if archive_args["compression"] == "gzip":
+                options.append("!timestamp")
             if archive_args["level"]:
-                kwargs["options"] = f"compression-level={archive_args['level']}"
+                options.append(f"compression-level={archive_args['level']}")
             with libarchive.file_writer(
                 vendor_tarfile,
                 archive_args["format"],
                 archive_args["compression"],
-                **kwargs,
+                options=",".join(options),
             ) as new_archive:
-                new_archive.add_files(vendor_dir)
+                new_archive.add_files(vendor_dir, mtime=mtime, ctime=mtime, atime=mtime)
             os.chdir(cwd)
 
 


### PR DESCRIPTION
This commit stores the mtime of the go.mod file as the mtime for all files in the produced archive.

It also remove the optional timestamp in gz archive.

This is enought to get reproducible output for tar.gz, tar.xz and tar.zstd.

For `obscpio` files, it will not be possible to get reproducible output without some modifications to libarchive or not using libarchive for cpio output, so didn't do anything for this file format right now