### PR TITLE
Preserve symlinks on shutil.copytree archive to tempdir refs #66

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -250,7 +250,10 @@ def main():
 
     with tempfile.TemporaryDirectory() as tempdir:
         if os.path.isdir(archive):
-            shutil.copytree(archive, os.path.join(tempdir, archive))
+            # Preserve symlinks during copy, some Go tests test symlink loops
+            shutil.copytree(
+                src=archive, dst=os.path.join(tempdir, archive), symlinks=True
+            )
         else:
             extract(archive, tempdir)
 


### PR DESCRIPTION
Usage of shutil.copytree(archive, tempdir/archive) by default ignores symlinks. Add symlinks=True to copy the source archive verbatim preserving symlinks.

For most Go source trees symlinks are not present, but golangci-lint has tests which use and check for symlink loops. Invoking copytree() without symlinks=True will raise "Errno 40 Too many levels of symbolic links" and instantiate the symlink loop as a repeating path until limits are reached.

Also write src and dst as keyword arguments to clarify what we are passing.