### PR TITLE
Strip trailing slash to fix using go.mod in top level archive directory refs #71

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -214,9 +214,8 @@ def sanitize_subdir(basedir, subdir):
     ret = os.path.normpath(subdir)
     if basedir == os.path.commonpath([basedir, ret]):
         return ret
-    log.error("Invalid path: {ret} not subdir of {basedir}")
+    log.error(f"Invalid path: {ret} not subdir of {basedir}")
     exit(1)
-
 
 def main():
     log.info(f"Running OBS Source Service: {app_name}")
@@ -262,6 +261,7 @@ def main():
             or basename_from_archive(archive)
             or basename_from_archive_name(archive)
         )
+        basename = basename.split("/")[-1]
         if subdir:
             go_mod_path = sanitize_subdir(
                 tempdir, os.path.join(tempdir, basename, subdir, "go.mod")


### PR DESCRIPTION
It just showed invalid error (after fixing error log line)

ERROR:obs-service-go_modules:Invalid path: /home/adrian/space/home:adrianSuSE:branches:devel:Factory:git-workflow/gitea/gitea-src-1.24.0-rc0/go.mod not subdir of /tmp/tmp3ri9md1t

before since it expanded full path to archive but failed to strip it when comparing it in the tempdir