### PR TITLE
Ensure some level of compatibility with older libarchive

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -332,7 +332,17 @@ def main():
                 archive_args["compression"],
                 options=",".join(options),
             ) as new_archive:
-                new_archive.add_files(vendor_dir, mtime=mtime, ctime=mtime, atime=mtime)
+                try:
+                    new_archive.add_files(
+                        vendor_dir, mtime=mtime, ctime=mtime, atime=mtime
+                    )
+                except (
+                    TypeError
+                ):  # If using old libarchive fallback to old non reproducible behavior
+                    log.warning(
+                        "python libarchive is too old, unable to produce reproducible output"
+                    )
+                    new_archive.add_files(vendor_dir)
             os.chdir(cwd)
 
 


### PR DESCRIPTION
In order to allow users of distribution with old libarchive to use this service, catch the exception generated in this case and fallback to non reproducible behavior.

A message is logged to inform user of the situation