### PR TITLE
Add support go mod edit -replace via _service params

### DIFF
--- a/go_modules
+++ b/go_modules
@@ -194,18 +194,20 @@ def extract(filename, outdir):
     os.chdir(cwd)
 
 
-def cmd_go_mod(cmd, moddir):
+def cmd_go_mod(subcmd, moddir):
     """Execute go mod subcommand using subprocess.run().
     Capture both stderr and stdout as text.
     Log as info or error in this function body.
     Return CompletedProcess object to caller for control flow.
     """
-    log.info(f"go mod {cmd}")
+    cmd = ["go", "mod"]
+    cmd.extend(subcmd)
+    log.info(" ".join(cmd))
     # subprocess.run() returns CompletedProcess cp
     if sys.version_info >= (3, 7):
-        cp = run(["go", "mod", cmd], cwd=moddir, capture_output=True, text=True)
+        cp = run(cmd, cwd=moddir, capture_output=True, text=True)
     else:
-        cp = run(["go", "mod", cmd], cwd=moddir)
+        cp = run(cmd, cwd=moddir)
     if cp.returncode:
         log.error(cp.stderr.strip())
     return cp
@@ -289,7 +291,7 @@ def main():
             #   (validates checksums)
 
             # return value cp is type subprocess.CompletedProcess
-            cp = cmd_go_mod("download", go_mod_dir)
+            cp = cmd_go_mod(["download"], go_mod_dir)
             if cp.returncode:
                 if "invalid version" in cp.stderr:
                     log.warning(
@@ -302,12 +304,12 @@ def main():
                     log.error("go mod download failed")
                     exit(1)
 
-            cp = cmd_go_mod("vendor", go_mod_dir)
+            cp = cmd_go_mod(["vendor"], go_mod_dir)
             if cp.returncode:
                 log.error("go mod vendor failed")
                 exit(1)
 
-            cp = cmd_go_mod("verify", go_mod_dir)
+            cp = cmd_go_mod(["verify"], go_mod_dir)
             if cp.returncode:
                 log.error("go mod verify failed")
                 exit(1)

--- a/go_modules
+++ b/go_modules
@@ -213,6 +213,25 @@ def cmd_go_mod(subcmd, moddir):
     return cp
 
 
+def replace_modules(replace, go_mod_dir):
+    """Replace one or more modules
+    Parameter replace is a list of strings: 'module=replacement'
+    Returns boolean indicating go.mod and go.sum are modified
+    """
+    log.info(f"Replacing {len(replace)} modules")
+    for r in replace:
+        cp = cmd_go_mod(["edit", "-replace", r], go_mod_dir)
+        if cp.returncode:
+            log.error(f"go mod edit -replace={r} failed")
+            exit(1)
+    # run go mod tidy to update go.mod and go.sum
+    cp = cmd_go_mod(["tidy"], go_mod_dir)
+    if cp.returncode:
+        log.error("go mod tidy failed")
+        exit(1)
+    return True
+
+
 def sanitize_subdir(basedir, subdir):
     ret = os.path.normpath(subdir)
     if basedir == os.path.commonpath([basedir, ret]):
@@ -234,10 +253,17 @@ def main():
     parser.add_argument("--basename")
     parser.add_argument("--vendorname", default=DEFAULT_VENDOR_STEM)
     parser.add_argument("--subdir")
+    parser.add_argument(
+        "--replace",
+        action="append",
+        help="go mod edit replace argument: 'module=replacement'. Can be used multiple times.",
+    )
     args = parser.parse_args()
 
     outdir = args.outdir
     subdir = args.subdir
+
+    replace = args.replace
 
     archive_args = get_archive_parameters(args)
     vendor_tarname = f"{archive_args['vendorname']}.{archive_args['ext']}"
@@ -280,6 +306,12 @@ def main():
         else:
             log.error(f"File go.mod not found under {os.path.join(tempdir, basename)}")
             exit(1)
+
+        modified = False  # sentinel value indicating go.mod and go.sum modification
+        if args.replace:
+            # replace one or more modules
+            # go.mod and go.sum will be modified and should be included in vendor archive
+            modified = replace_modules(replace, go_mod_dir)
 
         if args.strategy == "vendor":
             # go subcommand sequence:
@@ -338,6 +370,13 @@ def main():
                     new_archive.add_files(
                         vendor_dir, mtime=mtime, ctime=mtime, atime=mtime
                     )
+                    if modified:
+                        new_archive.add_files(
+                            "go.mod", mtime=mtime, ctime=mtime, atime=mtime
+                        )
+                        new_archive.add_files(
+                            "go.sum", mtime=mtime, ctime=mtime, atime=mtime
+                        )
                 except (
                     TypeError
                 ):  # If using old libarchive fallback to old non reproducible behavior

--- a/go_modules.service
+++ b/go_modules.service
@@ -19,4 +19,7 @@
   <parameter name="vendorname">
     <description>Specify the name for the generated vendor tarball. Default: vendor</description>
   </parameter>
+  <parameter name="replace">
+    <description>Specify a module name and its replacement to be updated at vendoring time. Syntax must be a valid expression input to go mod edit -replace, e.g. github.com/go-jose/go-jose/v4=github.com/go-jose/go-jose/v4@v4.0.5. Can be used multiple times. Default: None.</description>
+  </parameter>
 </service>


### PR DESCRIPTION
Implement support for go mod edit -replace to update specific module versions in response to CVE. Refs #57 