### PR TITLE
Implement go mod edit -require using _service params

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,40 @@ go version -m <BINARYNAME> |grep jose
         =>      github.com/go-jose/go-jose/v4   v4.0.5
 ```
 
-As soon as the Go application upstream tags a newer release, remove the replace
+## Pin a specific module version with `go mod edit -require`
+
+In some cases, it is useful to explicitly require a module version, without replacing it. The `go mod edit -require` command can be used to ensure a specific version of a module is recorded in `go.mod`, even if it is only indirectly required by other dependencies.
+
+This is especially useful in the following scenarios:
+
+- Pinning a minimum secure version of a module to address a known vulnerability, as identified by govulncheck
+- Ensuring consistent dependency resolution across vendoring and build environments.
+- Promoting a fixed version of an indirectly required dependency to a first-class requirement in `go.mod`.
+
+### Example
+
+You can add a require param:
+
+```
+<service name="go_modules" mode="manual">
+  <param name="require">github.com/go-jose/go-jose/v4@v4.0.5</param>
+</service>
+```
+
+The `go.mod` will contain:
+
+```
+require github.com/go-jose/go-jose/v4 v4.0.5
+```
+
+and the binary’s module info will show the pinned version.
+
+```
+go version -m <binary> | grep jose
+        dep     github.com/go-jose/go-jose/v4    v4.0.5
+```
+
+As soon as the Go application upstream tags a newer release, remove the replace and require
 parameters from `_service` to return to pristine upstream sources and receive
 further updates to the dependency.
 

--- a/go_modules
+++ b/go_modules
@@ -232,6 +232,25 @@ def replace_modules(replace, go_mod_dir):
     return True
 
 
+def require_modules(require, go_mod_dir):
+    """Add require directives to go.mod for one or more modules
+    Parameter require is a list of strings: 'module@version'
+    Returns boolean indicating go.mod and go.sum are modified
+    """
+    log.info(f"Setting required versions for {len(require)} modules")
+    for r in require:
+        cp = cmd_go_mod(["edit", "-require", r], go_mod_dir)
+        if cp.returncode:
+            log.error(f"go mod edit -require={r} failed")
+            exit(1)
+    # run go mod tidy to update go.mod and go.sum
+    cp = cmd_go_mod(["tidy"], go_mod_dir)
+    if cp.returncode:
+        log.error("go mod tidy failed")
+        exit(1)
+    return True
+
+
 def sanitize_subdir(basedir, subdir):
     ret = os.path.normpath(subdir)
     if basedir == os.path.commonpath([basedir, ret]):
@@ -258,12 +277,18 @@ def main():
         action="append",
         help="go mod edit replace argument: 'module=replacement'. Can be used multiple times.",
     )
+    parser.add_argument(
+        "--require",
+        action="append",
+        help="go mod edit require argument: 'module@version'. Can be used multiple times.",
+    )
     args = parser.parse_args()
 
     outdir = args.outdir
     subdir = args.subdir
 
     replace = args.replace
+    require = args.require
 
     archive_args = get_archive_parameters(args)
     vendor_tarname = f"{archive_args['vendorname']}.{archive_args['ext']}"
@@ -312,6 +337,11 @@ def main():
             # replace one or more modules
             # go.mod and go.sum will be modified and should be included in vendor archive
             modified = replace_modules(replace, go_mod_dir)
+
+        if args.require:
+            # add require directives to go.mod for one or more modules
+            # go.mod and go.sum will be modified and should be included in vendor archive
+            modified = require_modules(require, go_mod_dir)
 
         if args.strategy == "vendor":
             # go subcommand sequence:

--- a/go_modules.service
+++ b/go_modules.service
@@ -22,4 +22,7 @@
   <parameter name="replace">
     <description>Specify a module name and its replacement to be updated at vendoring time. Syntax must be a valid expression input to go mod edit -replace, e.g. github.com/go-jose/go-jose/v4=github.com/go-jose/go-jose/v4@v4.0.5. Can be used multiple times. Default: None.</description>
   </parameter>
+  <parameter name="require">
+    <description>Specify a module and version to be explicitly required in go.mod. Syntax must be a valid input to go mod edit -require, e.g. github.com/go-jose/go-jose/v4@v4.0.5. Can be used multiple times. Default: None.</description>
+  </parameter>
 </service>


### PR DESCRIPTION
This PR is entirely reusing the logic introduced in PR  https://github.com/openSUSE/obs-service-go_modules/pull/74 (original implementation for `go mod edit -replace` support) –  to also extend support for `go mod edit -require` operations.

This is an extension of the usecase tracked in #57 .

(Apologies, I missed spotting the use of `require` directives earlier. This was surfaced out while testing the `require` param support. Thanks, the `replace` param is working as intended and is extremely useful.
Ref - https://github.com/rancher/image-build-crictl/blob/36657fb04c0a28f723375939cd46d2a410d4f0d0/Dockerfile#L28)

cc: @jfkw 