### PR TITLE
New strategy: gomodcache

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The authoritative source is https://github.com/openSUSE/obs-service-go_modules.
 Using
 [`go.mod` and `go.sum`](https://github.com/golang/go/wiki/Modules)
 present in a Go application,
-`obs-service-go_modules` will call Go tools in sequence:
+`obs-service-go_modules` using the default strategy `vendor` will call Go tools in sequence:
 
 ```
 go mod download
@@ -39,6 +39,10 @@ go mod vendor
 
 `obs-service-go_modules` will create a `vendor.tar.gz` archive or other supported compression type
 containing the `vendor/` directory populated by `go mod vendor`.
+
+In some cases it can useful to use the `gomodcache` strategy which omits the `go mod vendor` step and creates
+a `gomodcache.tar.gz` archive containing the `$GOMODCACHE/cache` directory populated by `go mod download`.
+
 The archive is generated in the rpm package directory, and can be committed to
 [OBS](https://build.opensuse.org) to facilitate offline Go application package builds
 for [openSUSE](https://www.opensuse.org),
@@ -155,6 +159,13 @@ To ensure the top-level `vendor/` directory is used by go build, either:
 - pass the argument `go build -mod=vendor` to each invocation
 
 - set environment variable `GOFLAGS=-mod=vendor` to apply the setting to all invocations
+
+### Using the `gomodcache` strategy
+
+During `%setup` use the `-b…` option to uncompress the gomodcache archive before entering the working directory.
+
+Set the environment variable `GOMODCACHE=%{_builddir}/gomodcache` and either run `go mod vendor` in the `%setup` or `%build`
+section or just don't use the `-mod=vendor` option mentioned above.
 
 More information about additional controls is available at:
 [Go Module Knobs](https://github.com/thepudds/go-module-knobs/blob/master/README.md),

--- a/go_modules
+++ b/go_modules
@@ -194,6 +194,7 @@ def extract(filename, outdir):
 
     os.chdir(cwd)
 
+
 def pack(files: list, workdir: os.PathLike, mtime: float, args: dict):
     archive_args = get_archive_parameters(args)
     outdir = args.outdir
@@ -219,9 +220,7 @@ def pack(files: list, workdir: os.PathLike, mtime: float, args: dict):
     ) as new_archive:
         try:
             for file in files:
-                new_archive.add_files(
-                    file, mtime=mtime, ctime=mtime, atime=mtime
-                )
+                new_archive.add_files(file, mtime=mtime, ctime=mtime, atime=mtime)
         except (
             TypeError
         ):  # If using old libarchive fallback to old non reproducible behavior
@@ -229,10 +228,11 @@ def pack(files: list, workdir: os.PathLike, mtime: float, args: dict):
                 "python libarchive is too old, unable to produce reproducible output"
             )
             for file in files:
-                new_archive.add_files(files)
+                new_archive.add_files(file)
     os.chdir(cwd)
 
-def cmd_go_mod(subcmd, moddir, goenv = None):
+
+def cmd_go_mod(subcmd, moddir, goenv=None):
     """Execute go mod subcommand using subprocess.run().
     Capture both stderr and stdout as text.
     Log as info or error in this function body.
@@ -419,12 +419,7 @@ def main():
             if modified:
                 files.extend(["go.mod", "go.sum"])
 
-            pack(
-                files = files,
-                workdir = go_mod_dir,
-                mtime = go_mod_mtime,
-                args = args
-            )
+            pack(files=files, workdir=go_mod_dir, mtime=go_mod_mtime, args=args)
 
         elif args.strategy == "gomodcache":
             # Tars the GOMODCACHE dir only. Does not run 'go mod vendor'
@@ -434,7 +429,7 @@ def main():
 
             gomodcache_dir = DEFAULT_MODCACHE_STEM
             gomodcache_path = os.path.join(tempdir, gomodcache_dir)
-            goenv = { "GOMODCACHE": gomodcache_path }
+            goenv = {"GOMODCACHE": gomodcache_path}
 
             # return value cp is type subprocess.CompletedProcess
             cp = cmd_go_mod(["download"], go_mod_dir, goenv)
@@ -456,12 +451,7 @@ def main():
                 exit(1)
 
             cache_dir = os.path.join(gomodcache_dir, "cache")
-            pack(
-                files = [cache_dir],
-                workdir = tempdir,
-                mtime = go_mod_mtime,
-                args = args
-            )
+            pack(files=[cache_dir], workdir=tempdir, mtime=go_mod_mtime, args=args)
 
             if modified:
                 log.info("Copy modified go.mod & go.sum to source dir")
@@ -472,8 +462,8 @@ def main():
             log.error(f"Unknown strategy `{args.strategy}`")
             exit(1)
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     log = logging.getLogger(app_name)
     main()
-

--- a/go_modules
+++ b/go_modules
@@ -426,7 +426,7 @@ def main():
                 args = args
             )
 
-        elif args.strategy == "download":
+        elif args.strategy == "gomodcache":
             # Tars the GOMODCACHE dir only. Does not run 'go mod vendor'
             # Use it by untaring to the COMODCACHE dir and run 'go mod vendor' during build (in the spec).
 

--- a/go_modules
+++ b/go_modules
@@ -45,6 +45,7 @@ description = __doc__
 
 DEFAULT_COMPRESSION = "gz"
 DEFAULT_VENDOR_STEM = "vendor"
+DEFAULT_MODCACHE_STEM = "gomodcache"
 
 
 def get_archive_parameters(args):
@@ -321,6 +322,7 @@ def main():
     )
     args = parser.parse_args()
 
+    outdir = args.outdir
     subdir = args.subdir
 
     replace = args.replace
@@ -417,7 +419,12 @@ def main():
             if modified:
                 files.extend(["go.mod", "go.sum"])
 
-            pack(files = files, workdir = go_mod_dir, mtime = go_mod_mtime, args = args)
+            pack(
+                files = files,
+                workdir = go_mod_dir,
+                mtime = go_mod_mtime,
+                args = args
+            )
 
         elif args.strategy == "download":
             # Tars the GOMODCACHE dir only. Does not run 'go mod vendor'
@@ -425,7 +432,7 @@ def main():
 
             log.info(f"Using strategy `{args.strategy}`")
 
-            gomodcache_dir = os.path.join("go", "pkg", "mod")
+            gomodcache_dir = DEFAULT_MODCACHE_STEM
             gomodcache_path = os.path.join(tempdir, gomodcache_dir)
             goenv = { "GOMODCACHE": gomodcache_path }
 
@@ -449,10 +456,20 @@ def main():
                 exit(1)
 
             cache_dir = os.path.join(gomodcache_dir, "cache")
-            pack(files = [cache_dir], workdir = tempdir, mtime = go_mod_mtime, args = args)
+            pack(
+                files = [cache_dir],
+                workdir = tempdir,
+                mtime = go_mod_mtime,
+                args = args
+            )
+
+            if modified:
+                log.info("Copy modified go.mod & go.sum to source dir")
+                shutil.copy(src=go_mod_path, dst=outdir)
+                shutil.copy(src=os.path.join(go_mod_dir, "go.sum"), dst=outdir)
 
         else:
-            log.info(f"Unknown strategy `{args.strategy}`")
+            log.error(f"Unknown strategy `{args.strategy}`")
             exit(1)
 
 if __name__ == "__main__":

--- a/go_modules
+++ b/go_modules
@@ -193,8 +193,45 @@ def extract(filename, outdir):
 
     os.chdir(cwd)
 
+def pack(files: list, workdir: os.PathLike, mtime: float, args: dict):
+    archive_args = get_archive_parameters(args)
+    outdir = args.outdir
+    vendor_tarname = f"{archive_args['vendorname']}.{archive_args['ext']}"
+    vendor_tarfile = os.path.join(outdir, vendor_tarname)
 
-def cmd_go_mod(subcmd, moddir):
+    cwd = os.getcwd()
+    os.chdir(workdir)
+
+    log.info(f"Vendor go.mod dependencies to {vendor_tarname}")
+    log.debug(f"Set archive files times to {mtime}")
+
+    options = []
+    if archive_args["compression"] == "gzip":
+        options.append("!timestamp")
+    if archive_args["level"]:
+        options.append(f"compression-level={archive_args['level']}")
+    with libarchive.file_writer(
+        vendor_tarfile,
+        archive_args["format"],
+        archive_args["compression"],
+        options=",".join(options),
+    ) as new_archive:
+        try:
+            for file in files:
+                new_archive.add_files(
+                    file, mtime=mtime, ctime=mtime, atime=mtime
+                )
+        except (
+            TypeError
+        ):  # If using old libarchive fallback to old non reproducible behavior
+            log.warning(
+                "python libarchive is too old, unable to produce reproducible output"
+            )
+            for file in files:
+                new_archive.add_files(files)
+    os.chdir(cwd)
+
+def cmd_go_mod(subcmd, moddir, goenv = None):
     """Execute go mod subcommand using subprocess.run().
     Capture both stderr and stdout as text.
     Log as info or error in this function body.
@@ -205,9 +242,9 @@ def cmd_go_mod(subcmd, moddir):
     log.info(" ".join(cmd))
     # subprocess.run() returns CompletedProcess cp
     if sys.version_info >= (3, 7):
-        cp = run(cmd, cwd=moddir, capture_output=True, text=True)
+        cp = run(cmd, cwd=moddir, env=goenv, capture_output=True, text=True)
     else:
-        cp = run(cmd, cwd=moddir)
+        cp = run(cmd, cwd=moddir, env=goenv)
     if cp.returncode:
         log.error(cp.stderr.strip())
     return cp
@@ -284,14 +321,11 @@ def main():
     )
     args = parser.parse_args()
 
-    outdir = args.outdir
     subdir = args.subdir
 
     replace = args.replace
     require = args.require
 
-    archive_args = get_archive_parameters(args)
-    vendor_tarname = f"{archive_args['vendorname']}.{archive_args['ext']}"
     if args.archive:
         archive_matches = sorted(Path.cwd().glob(args.archive), reverse=True)
         if not archive_matches:
@@ -327,6 +361,7 @@ def main():
             )
         if go_mod_path and os.path.exists(go_mod_path):
             go_mod_dir = os.path.dirname(go_mod_path)
+            go_mod_mtime = os.path.getmtime(go_mod_path)
             log.info(f"Using go.mod found at {go_mod_path}")
         else:
             log.error(f"File go.mod not found under {os.path.join(tempdir, basename)}")
@@ -352,6 +387,8 @@ def main():
             # - go mod verify
             #   (validates checksums)
 
+            log.info(f"Using strategy `{args.strategy}`")
+
             # return value cp is type subprocess.CompletedProcess
             cp = cmd_go_mod(["download"], go_mod_dir)
             if cp.returncode:
@@ -376,48 +413,50 @@ def main():
                 log.error("go mod verify failed")
                 exit(1)
 
-            log.info(f"Vendor go.mod dependencies to {vendor_tarname}")
-            vendor_tarfile = os.path.join(outdir, vendor_tarname)
-            cwd = os.getcwd()
-            os.chdir(go_mod_dir)
-            vendor_dir = "vendor"
+            files = ["vendor"]
+            if modified:
+                files.extend(["go.mod", "go.sum"])
 
-            mtime = os.path.getmtime(go_mod_path)
-            log.debug(f"Set archive files times to {mtime}")
+            pack(files = files, workdir = go_mod_dir, mtime = go_mod_mtime, args = args)
 
-            options = []
-            if archive_args["compression"] == "gzip":
-                options.append("!timestamp")
-            if archive_args["level"]:
-                options.append(f"compression-level={archive_args['level']}")
-            with libarchive.file_writer(
-                vendor_tarfile,
-                archive_args["format"],
-                archive_args["compression"],
-                options=",".join(options),
-            ) as new_archive:
-                try:
-                    new_archive.add_files(
-                        vendor_dir, mtime=mtime, ctime=mtime, atime=mtime
-                    )
-                    if modified:
-                        new_archive.add_files(
-                            "go.mod", mtime=mtime, ctime=mtime, atime=mtime
-                        )
-                        new_archive.add_files(
-                            "go.sum", mtime=mtime, ctime=mtime, atime=mtime
-                        )
-                except (
-                    TypeError
-                ):  # If using old libarchive fallback to old non reproducible behavior
+        elif args.strategy == "download":
+            # Tars the GOMODCACHE dir only. Does not run 'go mod vendor'
+            # Use it by untaring to the COMODCACHE dir and run 'go mod vendor' during build (in the spec).
+
+            log.info(f"Using strategy `{args.strategy}`")
+
+            gomodcache_dir = os.path.join("go", "pkg", "mod")
+            gomodcache_path = os.path.join(tempdir, gomodcache_dir)
+            goenv = { "GOMODCACHE": gomodcache_path }
+
+            # return value cp is type subprocess.CompletedProcess
+            cp = cmd_go_mod(["download"], go_mod_dir, goenv)
+            if cp.returncode:
+                if "invalid version" in cp.stderr:
                     log.warning(
-                        "python libarchive is too old, unable to produce reproducible output"
+                        "go mod download is more sensitive to invalid module versions than go mod vendor"
                     )
-                    new_archive.add_files(vendor_dir)
-            os.chdir(cwd)
+                    log.warning(
+                        "if go mod vendor and go mod verify complete, vendoring is successful"
+                    )
+                else:
+                    log.error("go mod download failed")
+                    exit(1)
 
+            cp = cmd_go_mod(["verify"], go_mod_dir, goenv)
+            if cp.returncode:
+                log.error("go mod verify failed")
+                exit(1)
+
+            cache_dir = os.path.join(gomodcache_dir, "cache")
+            pack(files = [cache_dir], workdir = tempdir, mtime = go_mod_mtime, args = args)
+
+        else:
+            log.info(f"Unknown strategy `{args.strategy}`")
+            exit(1)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     log = logging.getLogger(app_name)
     main()
+

--- a/go_modules.service
+++ b/go_modules.service
@@ -2,7 +2,7 @@
   <summary>OBS Source Service to download, verify and vendor Go module dependency sources</summary>
   <description>This service for Go applications creates a vendor.tar.gz of Go module dependencies allowing fully offline builds in OBS. The service extracts Go application sources, reads the files go.mod and go.sum, then downloads and verifies Go module dependencies. The generated tarball will unpack to directory vendor which enables vendor mode. In vendor mode, the contents of the vendor directory will be used to load packages instead of the network or local module cache.</description>
   <parameter name="strategy">
-    <description>Choose the strategy this service runs in. Values: vendor, download. Default: vendor</description>
+    <description>Choose the strategy this service runs in. Values: vendor, gomodcache. Default: vendor</description>
   </parameter>
   <parameter name="archive">
     <description>Specify the Go application source archive that contains go.mod and go.sum. Values: app-x.y.z.tar.gz. Default: None, will use autodetection</description>

--- a/go_modules.service
+++ b/go_modules.service
@@ -2,7 +2,7 @@
   <summary>OBS Source Service to download, verify and vendor Go module dependency sources</summary>
   <description>This service for Go applications creates a vendor.tar.gz of Go module dependencies allowing fully offline builds in OBS. The service extracts Go application sources, reads the files go.mod and go.sum, then downloads and verifies Go module dependencies. The generated tarball will unpack to directory vendor which enables vendor mode. In vendor mode, the contents of the vendor directory will be used to load packages instead of the network or local module cache.</description>
   <parameter name="strategy">
-    <description>Choose the strategy this service runs in. Values: vendor. Default: vendor</description>
+    <description>Choose the strategy this service runs in. Values: vendor, download. Default: vendor</description>
   </parameter>
   <parameter name="archive">
     <description>Specify the Go application source archive that contains go.mod and go.sum. Values: app-x.y.z.tar.gz. Default: None, will use autodetection</description>


### PR DESCRIPTION
Implement a new strategy which creates a tarball of the GOMODCACHE-dir.
That enables packagers to use `GOMODCACHE=/path/to/cachedir go mod vendor` at build time.

### Use case:
We are packaging https://goharbor.io. It uses go-swagger to create server code. Because we run go-swagger at build time we can not use this service with the 'vendor' strategy before build time. It throws an error as it can not find the libraries that go-swagger has not yet created.
With the `gomodcache` strategy it works flawlessly.


